### PR TITLE
strawberry support

### DIFF
--- a/graphdoc/render.py
+++ b/graphdoc/render.py
@@ -46,8 +46,6 @@ def to_doc(
     use_cache=True,
 ) -> str:
     """Returns an html with the documentation from the schema"""
-    if hasattr(schema, "_schema"):
-        schema = schema._schema
     if context is not None and use_cache:
         raise ValueError("use_cache must be False if context is not None")
     if use_cache is True:

--- a/graphdoc/render.py
+++ b/graphdoc/render.py
@@ -46,6 +46,8 @@ def to_doc(
     use_cache=True,
 ) -> str:
     """Returns an html with the documentation from the schema"""
+    if hasattr(schema, "_schema"):
+        schema = schema._schema
     if context is not None and use_cache:
         raise ValueError("use_cache must be False if context is not None")
     if use_cache is True:

--- a/graphdoc/utilities.py
+++ b/graphdoc/utilities.py
@@ -16,7 +16,7 @@ def unwrap_field_type(
     """
     while isinstance(field_type, (graphql.GraphQLNonNull, graphql.GraphQLList)):
         field_type = field_type.of_type
-    if not hasattr(field_type, 'type'):
+    if not hasattr(field_type, "type"):
         field_type.type = field_type
     return field_type
 
@@ -58,7 +58,7 @@ def build_types_reference(
         for name, field in reference.mutation.fields.items():
             # Wrap all mutation fields to set the unwrapped_type attr
             unwrapped_type = unwrap_field_type(field.type)
-            if not hasattr(unwrapped_type, 'fields'):
+            if not hasattr(unwrapped_type, "fields"):
                 unwrapped_type.fields = {name: field}
             wrapper = definitions.GraphQLField(field)
             wrapper.unwrapped_type = unwrapped_type

--- a/graphdoc/utilities.py
+++ b/graphdoc/utilities.py
@@ -56,6 +56,12 @@ def build_types_reference(
         for name, field in reference.mutation.fields.items():
             # Wrap all mutation fields to set the unwrapped_type attr
             unwrapped_type = unwrap_field_type(field.type)
+            if not hasattr(unwrapped_type, 'type'):
+                unwrapped_type.type = field.type
+            if not hasattr(unwrapped_type, 'fields'):
+                unwrapped_type.fields = {
+                    unwrapped_type.name: unwrapped_type,
+                }
             wrapper = definitions.GraphQLField(field)
             wrapper.unwrapped_type = unwrapped_type
             reference.mutation.fields[name] = wrapper

--- a/graphdoc/utilities.py
+++ b/graphdoc/utilities.py
@@ -16,6 +16,8 @@ def unwrap_field_type(
     """
     while isinstance(field_type, (graphql.GraphQLNonNull, graphql.GraphQLList)):
         field_type = field_type.of_type
+    if not hasattr(field_type, 'type'):
+        field_type.type = field_type
     return field_type
 
 
@@ -56,12 +58,8 @@ def build_types_reference(
         for name, field in reference.mutation.fields.items():
             # Wrap all mutation fields to set the unwrapped_type attr
             unwrapped_type = unwrap_field_type(field.type)
-            if not hasattr(unwrapped_type, 'type'):
-                unwrapped_type.type = field.type
             if not hasattr(unwrapped_type, 'fields'):
-                unwrapped_type.fields = {
-                    unwrapped_type.name: unwrapped_type,
-                }
+                unwrapped_type.fields = {name: field}
             wrapper = definitions.GraphQLField(field)
             wrapper.unwrapped_type = unwrapped_type
             reference.mutation.fields[name] = wrapper


### PR DESCRIPTION
The library currently does not support schema from strawberry graphql.

Added support to read strawberry schema  from schema._schema.

extended unwrapped type to cater for types coming from strawberry that dont include the fields "type,fields"
