### PR TITLE
Fix `grapdoc.to_md` by adding missing markdown templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/wallee94/graphdoc",
     packages=setuptools.find_packages(),
-    package_data={'graphdoc': ['templates/*.html', 'md_templates/*.*']},
+    package_data={'graphdoc': ['templates/*.html', 'templates/markdown/*.md']},
     install_requires=[
         'graphql-core>=2.1.0,<4',
         'Jinja2>=2',


### PR DESCRIPTION
This PR fixes `graphdoc.to_md` by updating setup.py to include the markdown templates when releasing the graphdoc package.

Currently this method returns HTML. This is due to the check in render.py (at https://github.com/wallee94/graphdoc/blob/main/graphdoc/render.py#L29) failing to find the markdown templates, and therefore not loading them templates into the `_jinja_env`. As a result, the renderer still produces HTML.